### PR TITLE
Handle null exception when closing P2P session

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -143,19 +143,19 @@ namespace EpicTransport {
         }
 
         protected virtual void CloseP2PSessionWithUser(ProductUserId clientUserID, SocketId socketId) {
-			if (socketId == null)
-			{
-				Debug.LogWarning("Socket ID == null | " + ignoreAllMessages);
-				return;
-			}
+            if (socketId == null)
+            {
+                Debug.LogWarning("Socket ID == null | " + ignoreAllMessages);
+                return;
+            }
 
-			if (deadSockets == null)
-			{
-				Debug.LogWarning("DeadSockets == null");
-				return;
-			}
+            if (deadSockets == null)
+            {
+                Debug.LogWarning("DeadSockets == null");
+                return;
+            }
 
-			if (deadSockets.Contains(socketId.SocketName)) {
+            if (deadSockets.Contains(socketId.SocketName)) {
                 return;
             } else {
                 deadSockets.Add(socketId.SocketName);

--- a/Common.cs
+++ b/Common.cs
@@ -143,15 +143,19 @@ namespace EpicTransport {
         }
 
         protected virtual void CloseP2PSessionWithUser(ProductUserId clientUserID, SocketId socketId) {
-            if(socketId == null) {
-                Debug.LogError("Socket ID == null | " + ignoreAllMessages);
-            }
+			if (socketId == null)
+			{
+				Debug.LogWarning("Socket ID == null | " + ignoreAllMessages);
+				return;
+			}
 
-            if(deadSockets == null) {
-                Debug.LogError("DeadSockets == null");
-            }
+			if (deadSockets == null)
+			{
+				Debug.LogWarning("DeadSockets == null");
+				return;
+			}
 
-            if (deadSockets.Contains(socketId.SocketName)) {
+			if (deadSockets.Contains(socketId.SocketName)) {
                 return;
             } else {
                 deadSockets.Add(socketId.SocketName);


### PR DESCRIPTION
### Summary
This PR addresses a potential issue where messages whose `socketId` has become null after being enqueued due to a user suddenly being disconnected by the server. Allowing the `RecieveData` method to continue normally instead of causing cascading errors.