### PR TITLE
Fixed OnClientDisconnected not invoked when client is null

### DIFF
--- a/Mirror/Runtime/Transport/EpicOnlineTransport/EosTransport.cs
+++ b/Mirror/Runtime/Transport/EpicOnlineTransport/EosTransport.cs
@@ -231,6 +231,12 @@ namespace EpicTransport {
 
             for(int i  = 0; i < packets.Length; i++) {
                 if (connectionId == int.MinValue) {
+                    if (client == null)
+                    {
+                        OnClientDisconnected.Invoke();
+                        return;
+                    }
+                    
                     client.Send(packets[i].ToBytes(), channelId);
                 } else {
                     server.SendAll(connectionId, packets[i].ToBytes(), channelId);


### PR DESCRIPTION
I have added a checking for client null before Send any message. Otherwise it became null when there is a bug and client is disconnected, but OnClientDisconnected() function is not invoked and client is not correctly disconnected.